### PR TITLE
chore: update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,14 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>20.4</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.23.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.19.0</gravitee-common.version>
+        <gravitee-bom.version>3.0.19</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.0.3</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <jsoup.version>1.9.1</jsoup.version>
+        <jsoup.version>1.17.2</jsoup.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <jsoup.version>1.17.2</jsoup.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>


### PR DESCRIPTION
**Description**

Upgrade all Gravitee dependencies using the version defined in the latest 3.20.
Upgrade `jsoup`

**Additional context**

I've tested manually on a basic example.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.3-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-html-json/1.6.3-bump-dependencies-SNAPSHOT/gravitee-policy-html-json-1.6.3-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
